### PR TITLE
Just a little link error to "Twitter Scrapper" repository on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ npm run ci && npm run build
 ## Configuration
 Touitomamout relies on two APIs:
 - [Mastodon](https://docs.joinmastodon.org/client/intro/)
-- [Twitter-Scrapper](https://github.com/@the-convocation/twitter-scraper)
+- [Twitter-Scrapper](https://github.com/the-convocation/twitter-scraper)
 
 ### Mastodon configuration
 In order to communicate with the mastodon instance, you'll have to generate an API Token. It's totally free. Reminder: your application name will be publicly visible. 


### PR DESCRIPTION
Before

```md
- [Twitter-Scrapper](https://github.com/@the-convocation/twitter-scraper)
```

After : 
```md
- [Twitter-Scrapper](https://github.com/the-convocation/twitter-scraper)
```
